### PR TITLE
Windows compatibility fixes

### DIFF
--- a/src/main/java/org/andresoviedo/apps/gdrive_ftp_adapter/view/ftp/GFtpServerFactory.java
+++ b/src/main/java/org/andresoviedo/apps/gdrive_ftp_adapter/view/ftp/GFtpServerFactory.java
@@ -700,17 +700,17 @@ public class GFtpServerFactory extends FtpServerFactory {
 				// windows doesn't distinguish the case, unix does
 				// windows & linux can't have repeated filenames
 				// TODO: other OS I don't know yet...
-				String filename = OSUtils.isWindows() ? fileWrapper.getName().toLowerCase() : OSUtils.isUnix() ? fileWrapper
-						.getName() : fileWrapper.getName();
+				String filename = fileWrapper.getName();
+				String uniqueFilename = OSUtils.isWindows() ? filename.toLowerCase() : OSUtils.isUnix() ? filename : filename;
 
 				// check if the filename is not yet duplicated
-				if (!allFilenames.containsKey(filename)) {
-					allFilenames.put(filename, fileWrapper);
+				if (!allFilenames.containsKey(uniqueFilename)) {
+					allFilenames.put(uniqueFilename, fileWrapper);
 					continue;
 				}
 
 				// these are the repeated files
-				final FtpFileWrapper firstFileDuplicated = allFilenames.get(filename);
+				final FtpFileWrapper firstFileDuplicated = allFilenames.get(uniqueFilename);
 				firstFileDuplicated.setVirtualName(encodeFilename(filename, firstFileDuplicated.getId()));
 				fileWrapper.setVirtualName(encodeFilename(filename, ftpFile.getId()));
 

--- a/src/main/java/org/andresoviedo/apps/gdrive_ftp_adapter/view/ftp/GFtpServerFactory.java
+++ b/src/main/java/org/andresoviedo/apps/gdrive_ftp_adapter/view/ftp/GFtpServerFactory.java
@@ -432,6 +432,9 @@ public class GFtpServerFactory extends FtpServerFactory {
 			try {
 				// initialize working directory in case this is the first call
 				initWorkingDirectory();
+				
+				// remove trailing FILE_SEPARATOR (but keep leading ones)
+				if (path.length() > 1 && path.endsWith(FILE_SEPARATOR)) path = path.substring(0, path.length()-1);
 
 				LOG.debug("Changing working directory from '" + currentDir + "' to '" + path + "'...");
 
@@ -552,7 +555,7 @@ public class GFtpServerFactory extends FtpServerFactory {
 			}
 
 			FtpFileWrapper folder;
-			if (path.startsWith(currentDir.getAbsolutePath() + FILE_SEPARATOR)) {
+			if (path.startsWith(currentDir.isRoot() ? currentDir.getAbsolutePath() : currentDir.getAbsolutePath() + FILE_SEPARATOR)) {
 				// get the relative filename
 				folder = currentDir;
 				path = path.substring(folder.getAbsolutePath().length() + 1);


### PR DESCRIPTION
fixing two issues, which do occur on Windows 8.1 and probably other Windows versions.

1. Windows Explorer sends a trailing path separator in its CWD (change working directory) commands. That is not compatible with the current implementation, which expects a path without a trailing path separator in its path comparisons. The fix removes the trailing path separator for the CWD processing.

2. Accessing duplicate files did not work on Windows. The problem was caused by the lower case conversion of the file name, which resulted in a failing internal check for filename equivalence. This fix uses the lower-case name only for duplicate checking internally, and uses the original case in the encoded filename.