### PR TITLE
Standardise Authentication port 

### DIFF
--- a/build/configuration.properties
+++ b/build/configuration.properties
@@ -1,27 +1,30 @@
 # log4j.fileId if you have more than 1 instance of the app running
 #log4j.fileId=
-# account name associated to cache & google credentials 
+# account name associated to cache & google credentials
 #account=default
 # FTP binding address where application will listen for incoming connections
 #server=
 # TCP port where the application will listen for incoming connections
-port=1821
+#port=1821
+#Port where the authentication server listens
+#auth.port=8093
 # FTP anonymous login
-ftp.anonymous.enabled=false
-ftp.anonymous.home=
-ftp.anonymous.rights=pwd|cd|dir|put|get|rename|delete|mkdir|rmdir|append
+#ftp.anonymous.enabled=false
+#ftp.anonymous.home=
+#ftp.anonymous.rights=pwd|cd|dir|put|get|rename|delete|mkdir|rmdir|append
 # FTP users credentials
-ftp.user=user
-ftp.pass=user
-ftp.home=
-ftp.rights=pwd|cd|dir|put|get|rename|delete|mkdir|rmdir|append
-ftp.user2=bar
-ftp.pass2=barpass
-ftp.home2=path/to/bar/home
-ftp.rights2=pwd|get
-ftp.user3=baz
-ftp.pass3=bazpass
-ftp.home3=path/to/baz/home
-ftp.rights3=dir|put
-# Illegal characters for your file system so file copying works fine  
-os.illegalCharacters=\\/|[\\x00-\\x1F\\x7F]|\\`|\\?|\\*|\\\\|\\<|\\>|\\||\\"|\\:
+#ftp.user=user
+#ftp.pass=user
+#ftp.home=path/to/home/directory
+#ftp.rights=pwd|cd|dir|put|get|rename|delete|mkdir|rmdir|append
+#ftp.user2=
+#ftp.pass2=
+#ftp.home2=
+#ftp.rights2=
+#ftp.user3=
+#ftp.pass3=
+#ftp.home3=
+#ftp.rights3=
+# Illegal characters for your file system so file copying works fine
+#os.illegalCharacters=\\/|[\\x00-\\x1F\\x7F]|\\`|\\?|\\*|\\\\|\\<|\\>|\\||\\"|\\:
+

--- a/src/main/java/org/andresoviedo/google_drive_ftp_adapter/model/GoogleDriveFactory.java
+++ b/src/main/java/org/andresoviedo/google_drive_ftp_adapter/model/GoogleDriveFactory.java
@@ -34,6 +34,16 @@ public final class GoogleDriveFactory {
      * Application name as of Google Drive Service
      */
     private static final String APPLICATION_NAME = "google-drive-ftp-adapter";
+    
+    /**
+     * Default port for authentication server
+     */
+    private int authPort = -1;
+    
+    /**
+     * Local
+     */
+    
     /**
      * Global instance of the JSON factory.
      */
@@ -52,6 +62,8 @@ public final class GoogleDriveFactory {
     public GoogleDriveFactory(Properties configuration) {
         /* Directory to store user credentials. */
         java.io.File DATA_STORE_DIR = new java.io.File("data/google/" + configuration.getProperty("account", "default"));
+        
+        authPort = Integer.parseInt(configuration.getProperty("auth.port", String.valueOf("-1")));
 
         try {
             // initialize the data store factory
@@ -108,7 +120,7 @@ public final class GoogleDriveFactory {
         GoogleAuthorizationCodeFlow flow = new GoogleAuthorizationCodeFlow.Builder(httpTransport, JSON_FACTORY, clientSecrets, scopes)
                 .setDataStoreFactory(dataStoreFactory).build();
         // authorize
-        return new AuthorizationCodeInstalledApp(flow, new LocalServerReceiver()).authorize("user");
+        return new AuthorizationCodeInstalledApp(flow, new LocalServerReceiver.Builder().setPort(authPort).build()).authorize("user");
     }
 
     public Drive getDrive() {

--- a/src/main/resources/configuration.properties
+++ b/src/main/resources/configuration.properties
@@ -6,6 +6,8 @@
 #server=
 # TCP port where the application will listen for incoming connections
 #port=1821
+#Port where the authentication server listens
+#auth.port=8093
 # FTP anonymous login
 #ftp.anonymous.enabled=false
 #ftp.anonymous.home=


### PR DESCRIPTION
Added a property in the config file which will set the authentication server to listen at that port.

The property is called "auth.port". If this property is not specified the server will be setup at any randomised port. 